### PR TITLE
add mainProcurementCategory to the base tender model

### DIFF
--- a/openprocurement/tender/core/models.py
+++ b/openprocurement/tender/core/models.py
@@ -789,6 +789,7 @@ class BaseTender(OpenprocurementSchematicsDocument, Model):
     if SANDBOX_MODE:
         procurementMethodDetails = StringType()
     funders = ListType(ModelType(Organization), validators=[validate_funders_unique, validate_funders_ids])
+    mainProcurementCategory = StringType(choices=["goods", "services", "works"])
 
     _attachments = DictType(DictType(BaseType), default=dict())  # couchdb attachments
     revisions = ListType(ModelType(Revision), default=list())

--- a/openprocurement/tender/core/tests/models.py
+++ b/openprocurement/tender/core/tests/models.py
@@ -158,6 +158,40 @@ class TestQuestionModel(unittest.TestCase):
         self.assertEqual(len(serialized_question['id']), 32)
 
 
+class TestTenderMainProcurementCategory(unittest.TestCase):
+    def test_validate_valid(self):
+        tender = Tender(
+            {
+                "title": "whatever",
+                "mainProcurementCategory": "goods",
+            }
+        )
+        tender.validate()
+        data = tender.serialize("embedded")
+        self.assertIn("mainProcurementCategory", data)
+        self.assertIn(data["mainProcurementCategory"], "goods")
+
+    def test_validate_not_valid(self):
+        tender = Tender(
+            {
+                "title": "whatever",
+                "mainProcurementCategory": "test",
+            }
+        )
+        with self.assertRaises(ModelValidationError) as e:
+            tender.validate()
+        self.assertEqual(
+            e.exception.message,
+            {'mainProcurementCategory': [u"Value must be one of ['goods', 'services', 'works']."]}
+        )
+
+    def test_validate_empty(self):
+        tender = Tender({"title": "whatever"})
+        tender.validate()
+        data = tender.serialize("embedded")
+        self.assertNotIn("mainProcurementCategory", data)
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestPeriodEndRequired))


### PR DESCRIPTION
https://github.com/ProzorroUKR/openprocurement.tender.belowthreshold/pull/12
https://github.com/ProzorroUKR/openprocurement.tender.openua/pull/7
https://github.com/ProzorroUKR/openprocurement.tender.cfaua/pull/9
https://github.com/ProzorroUKR/openprocurement.tender.competitivedialogue/pull/4
https://github.com/ProzorroUKR/openprocurement.tender.esco/pull/6
https://github.com/ProzorroUKR/openprocurement.tender.limited/pull/7
https://github.com/ProzorroUKR/openprocurement.tender.openeu/pull/9
https://github.com/ProzorroUKR/openprocurement.tender.openuadefense/pull/7