### PR TITLE
remove revisions from model in case of GET requests

### DIFF
--- a/openprocurement/tender/core/tests/utils.py
+++ b/openprocurement/tender/core/tests/utils.py
@@ -159,6 +159,23 @@ class TestUtils(unittest.TestCase):
         model = tender_from_data(request, self.tender_data)
         self.assertIsInstance(model, Tender)
 
+    def test_tender_from_data_revisions(self):
+        request = MagicMock()
+        request.registry.tender_procurementMethodTypes = {"belowThreshold": Tender}
+
+        data = dict(**self.tender_data)
+        data["revisions"] = [dict(rev=i, author="me") for i in range(10)]
+
+        for method in ("GET", "POST", "PATCH", "PUT", "DELETE", "HEAD"):
+            request.environ = {"REQUEST_METHOD": method}
+            model = tender_from_data(request, data)
+
+            if method == "GET":
+                self.assertEqual(len(model.revisions), 1)
+                self.assertEqual(model.revisions[0].rev, "0")
+            else:
+                self.assertEqual(len(model.revisions), 10)
+
     @patch('openprocurement.tender.core.utils.decode_path_info')
     @patch('openprocurement.tender.core.utils.error_handler')
     def test_extract_tender(self, mocked_error_handler, mocked_decode_path):

--- a/openprocurement/tender/core/utils.py
+++ b/openprocurement/tender/core/utils.py
@@ -255,7 +255,13 @@ def tender_from_data(request, data, raise_error=True, create=True):
         raise error_handler(request.errors)
     update_logging_context(request, {'tender_type': procurementMethodType})
     if model is not None and create:
-        model = model(data)
+        if request.environ.get("REQUEST_METHOD") == "GET" and data.get("revisions"):
+            # to optimize get requests to tenders with many revisions
+            copy_data = dict(**data)  # changing of the initial dict is a bad practice
+            copy_data["revisions"] = data["revisions"][:1]  # leave first revision for validations
+            model = model(copy_data)
+        else:
+            model = model(data)
     return model
 
 


### PR DESCRIPTION
https://jira.prozorro.org/browse/CS-2638

Проверил использование в след местах:
1) Model validation (оставил первую ревизию для валидаций)
пример if tender.get('revisions') and tender['revisions'][0].date > BID_LOTVALUES_VALIDATION_FROM

2) HISTORICAL накатывает ревизии на json и только потом передает этой функции
3) В логах используется _rev -текущий номер ревизии коуча (не из этих полей)


Время ответа апи при 100000 ревизиях  (на локальной машине в тестах)
Без фикса 0:00:29.580782
С фиксом 0:00:01.992241